### PR TITLE
Make clear Toolbox is CLI and Maven plugin

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
               </a>
             </li>
             <li>
-              java (Maven Resolver) -
+              java (CLI + Maven) -
               <a href="https://github.com/maveniverse/toolbox">
                 Maveniverse Toolbox
               </a>


### PR DESCRIPTION
Just a minor update: make clear that Toolbox is a CLI and also a Maven plugin